### PR TITLE
Readme unified and check project against 23.10

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -54,6 +54,7 @@
 *.fsq filter=lfs diff=lfs merge=lfs -text
 *.fxl filter=lfs diff=lfs merge=lfs -text
 *.gfx filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
 *.grd filter=lfs diff=lfs merge=lfs -text
 *.i_caf filter=lfs diff=lfs merge=lfs -text
 *.icns filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -54,7 +54,6 @@
 *.fsq filter=lfs diff=lfs merge=lfs -text
 *.fxl filter=lfs diff=lfs merge=lfs -text
 *.gfx filter=lfs diff=lfs merge=lfs -text
-*.gif filter=lfs diff=lfs merge=lfs -text
 *.grd filter=lfs diff=lfs merge=lfs -text
 *.i_caf filter=lfs diff=lfs merge=lfs -text
 *.icns filter=lfs diff=lfs merge=lfs -text

--- a/Code/enabled_gems.cmake
+++ b/Code/enabled_gems.cmake
@@ -1,6 +1,5 @@
 
 set(ENABLED_GEMS
-    GameJam2021
     Atom
     AudioSystem
     AWSCore

--- a/Levels/GnomebodysHome/GnomebodysHome.prefab
+++ b/Levels/GnomebodysHome/GnomebodysHome.prefab
@@ -38,15 +38,174 @@
             },
             "Component_[7874177159288365422]": {
                 "$type": "EditorEntitySortComponent",
-                "Id": 7874177159288365422
+                "Id": 7874177159288365422,
+                "Child Entity Order": [
+                    "Entity_[710623382835]",
+                    "Entity_[865242205491]",
+                    "Entity_[813702597939]",
+                    "Entity_[869537172787]",
+                    "Entity_[445828575715]",
+                    "Entity_[1127235210547]",
+                    "Entity_[458713477603]",
+                    "Entity_[749278088499]",
+                    "Entity_[895306976563]",
+                    "Entity_[1024155995443]",
+                    "Entity_[455614690609]",
+                    "Entity_[648888218929]",
+                    "Entity_[480188314083]",
+                    "Entity_[985501289779]",
+                    "Entity_[843767369011]",
+                    "Entity_[666068088113]",
+                    "Entity_[450123543011]",
+                    "Entity_[835177434419]",
+                    "Entity_[597348611377]",
+                    "Entity_[714918350131]",
+                    "Entity_[399192484514]",
+                    "Entity_[399780115761]",
+                    "Entity_[2428610301235]",
+                    "Entity_[770752924979]",
+                    "Entity_[406924864191]",
+                    "Entity_[908191878451]",
+                    "Entity_[856652270899]",
+                    "Instance_[1208385370308]/ContainerEntity",
+                    "Entity_[809407630643]",
+                    "Entity_[568889462067]",
+                    "Entity_[1101465406771]",
+                    "Entity_[684853579059]",
+                    "Entity_[762162990387]",
+                    "Entity_[433009041281]",
+                    "Entity_[407782419106]",
+                    "Entity_[590364298547]",
+                    "Entity_[607544167731]",
+                    "Entity_[393422659954]",
+                    "Entity_[454418510307]",
+                    "Entity_[661773120817]",
+                    "Entity_[468499592497]",
+                    "Instance_[1642177067204]/ContainerEntity",
+                    "Entity_[1041335864627]",
+                    "Entity_[1122940243251]",
+                    "Entity_[1015566060851]",
+                    "Entity_[441598975873]",
+                    "Entity_[775047892275]",
+                    "Entity_[573184429363]",
+                    "Entity_[463008444899]",
+                    "Entity_[657478153521]",
+                    "Entity_[659083775283]",
+                    "Entity_[586069331251]",
+                    "Entity_[397090770227]",
+                    "Entity_[1131530177843]",
+                    "Entity_[671968677171]",
+                    "Entity_[1062810701107]",
+                    "Entity_[929666714931]",
+                    "Entity_[477089527089]",
+                    "Entity_[1019861028147]",
+                    "Entity_[676263644467]",
+                    "Entity_[577479396659]",
+                    "Entity_[428648706531]",
+                    "Entity_[766457957683]",
+                    "Entity_[805112663347]",
+                    "Entity_[403487451810]",
+                    "Entity_[515744232753]",
+                    "Entity_[1084285537587]",
+                    "Entity_[670363055409]",
+                    "Entity_[428714073985]",
+                    "Entity_[899601943859]",
+                    "Entity_[432943673827]",
+                    "Entity_[1088580504883]",
+                    "Entity_[1092875472179]",
+                    "Entity_[955436518707]",
+                    "Entity_[994091224371]",
+                    "Entity_[1075695602995]",
+                    "Entity_[702033448243]",
+                    "Instance_[1135370926276]/ContainerEntity",
+                    "Entity_[753573055795]",
+                    "Entity_[830882467123]",
+                    "Entity_[964026453299]",
+                    "Entity_[1114350308659]",
+                    "Entity_[424353739235]",
+                    "Entity_[697738480947]",
+                    "Entity_[1105760374067]",
+                    "Entity_[683247957297]",
+                    "Entity_[1049925799219]",
+                    "Entity_[723508284723]",
+                    "Entity_[925371747635]",
+                    "Entity_[817997565235]",
+                    "Entity_[507154298161]",
+                    "Entity_[878127107379]",
+                    "Entity_[560299527475]",
+                    "Instance_[839018182852]/ContainerEntity",
+                    "Entity_[429844886833]",
+                    "Entity_[558693905713]",
+                    "Entity_[1058515733811]",
+                    "Entity_[471598379491]",
+                    "Entity_[1097170439475]",
+                    "Entity_[581774363955]",
+                    "Entity_[1118645275955]",
+                    "Entity_[860947238195]",
+                    "Entity_[848062336307]",
+                    "Entity_[706328415539]",
+                    "Entity_[601643578673]",
+                    "Entity_[598954233139]",
+                    "Entity_[395859204812]",
+                    "Entity_[719213317427]",
+                    "Entity_[1079990570291]",
+                    "Entity_[402629896895]",
+                    "Entity_[998386191667]",
+                    "Entity_[732098219315]",
+                    "Entity_[1110055341363]",
+                    "Entity_[680558611763]",
+                    "Entity_[976911355187]",
+                    "Entity_[852357303603]",
+                    "Entity_[408370050353]",
+                    "Entity_[1006976126259]",
+                    "Entity_[424419106689]",
+                    "Entity_[736393186611]",
+                    "Entity_[1071400635699]",
+                    "Entity_[437304008577]",
+                    "Entity_[580168742193]",
+                    "Entity_[395485148465]",
+                    "Entity_[981206322483]",
+                    "Entity_[427155541299]",
+                    "Entity_[1045630831923]",
+                    "Entity_[968321420595]",
+                    "Entity_[610233513265]",
+                    "Entity_[693443513651]",
+                    "Entity_[412665017649]",
+                    "Entity_[441533608419]",
+                    "Entity_[972616387891]",
+                    "Entity_[420058771939]",
+                    "Entity_[437238641123]",
+                    "Entity_[398583935459]",
+                    "Entity_[653183186225]",
+                    "Entity_[603249200435]",
+                    "Entity_[564594494771]",
+                    "Entity_[826587499827]",
+                    "Entity_[839472401715]",
+                    "Entity_[822292532531]",
+                    "Entity_[528629134641]",
+                    "Entity_[1067105668403]",
+                    "Entity_[431450508595]",
+                    "Entity_[1037040897331]",
+                    "Entity_[873832140083]",
+                    "Entity_[740688153907]",
+                    "Entity_[411468837347]",
+                    "Entity_[989796257075]",
+                    "Entity_[594659265843]",
+                    "Entity_[1011271093555]",
+                    "Entity_[567283840305]",
+                    "Entity_[903896911155]",
+                    "Entity_[1054220766515]",
+                    "Entity_[689148546355]"
+                ]
             },
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
             },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
+            "LocalViewBookmarkComponent": {
+                "$type": "LocalViewBookmarkComponent",
+                "Id": 13268122148584704206,
+                "LocalBookmarkFileName": "GnomebodysHome_17142440915208149.setreg"
             }
         }
     },
@@ -130,10 +289,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
                 },
                 "Component_[3548952105967942507]": {
                     "$type": "EditorNonUniformScaleComponent",
@@ -230,10 +385,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[3548952105967942507]": {
                     "$type": "EditorNonUniformScaleComponent",
                     "Id": 3548952105967942507,
@@ -324,10 +475,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[7364378514629616014]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7364378514629616014
@@ -409,10 +556,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[7364378514629616014]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7364378514629616014
@@ -443,10 +586,6 @@
                 "Component_[14988063963197918512]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 14988063963197918512
-                },
-                "Component_[15381575011528215857]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15381575011528215857
                 },
                 "Component_[15631927763703886742]": {
                     "$type": "EditorNonUniformScaleComponent",
@@ -540,163 +679,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{88B99E7E-9507-57CA-BC64-1FB2F47DFEAA}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/waterfall_.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{88B99E7E-9507-57CA-BC64-1FB2F47DFEAA}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/waterfall_.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{88B99E7E-9507-57CA-BC64-1FB2F47DFEAA}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/waterfall_.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{88B99E7E-9507-57CA-BC64-1FB2F47DFEAA}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/waterfall_.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{88B99E7E-9507-57CA-BC64-1FB2F47DFEAA}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/waterfall_.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{88B99E7E-9507-57CA-BC64-1FB2F47DFEAA}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/waterfall_.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{88B99E7E-9507-57CA-BC64-1FB2F47DFEAA}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/waterfall_.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{88B99E7E-9507-57CA-BC64-1FB2F47DFEAA}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/waterfall_.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 }
             }
         },
@@ -707,10 +690,6 @@
                 "Component_[10004372573348948437]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 10004372573348948437
-                },
-                "Component_[10372021692304942886]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10372021692304942886
                 },
                 "Component_[10964204455601800022]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -736,123 +715,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{EC61F34A-0A23-53C5-AF15-FCB5C0703813}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/snowglobe.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 858141109
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 858141109
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 858141109
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 858141109
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 858141109
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 858141109
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 858141109
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 858141109
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 858141109
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 858141109
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 858141109
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 858141109
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 858141109
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 858141109
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 858141109
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 858141109
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[16212395994123509062]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -880,8 +743,7 @@
                                     "guid": "{483F4737-1C18-57DC-938A-5C852693FCF2}",
                                     "subId": 283487051
                                 },
-                                "loadBehavior": "PreLoad",
-                                "assetHint": "joshuas-assets/gamejam2021/snowglobe.azmodel"
+                                "assetHint": "joshuas-assets/gamejam2021/snowglobe.fbx.azmodel"
                             },
                             "LodOverride": 255
                         }
@@ -965,163 +827,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[15031379514475369613]": {
                     "$type": "EditorLockComponent",
@@ -1130,10 +836,6 @@
                 "Component_[15183822379560953471]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 15183822379560953471
-                },
-                "Component_[17112385175498437426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17112385175498437426
                 },
                 "Component_[18366445350205353132]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -1234,163 +936,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[15031379514475369613]": {
                     "$type": "EditorLockComponent",
@@ -1399,10 +945,6 @@
                 "Component_[15183822379560953471]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 15183822379560953471
-                },
-                "Component_[17112385175498437426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17112385175498437426
                 },
                 "Component_[18366445350205353132]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -1519,10 +1061,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 15752513506849964945
                 },
-                "Component_[2303614537700606121]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2303614537700606121
-                },
                 "Component_[295756399074028600]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 295756399074028600
@@ -1586,163 +1124,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 }
             }
         },
@@ -1795,10 +1177,6 @@
                 "Component_[15752513506849964945]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 15752513506849964945
-                },
-                "Component_[2303614537700606121]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2303614537700606121
                 },
                 "Component_[295756399074028600]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -1863,163 +1241,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 }
             }
         },
@@ -2079,163 +1301,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[15031379514475369613]": {
                     "$type": "EditorLockComponent",
@@ -2244,10 +1310,6 @@
                 "Component_[15183822379560953471]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 15183822379560953471
-                },
-                "Component_[17112385175498437426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17112385175498437426
                 },
                 "Component_[18366445350205353132]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -2355,10 +1417,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 15752513506849964945
                 },
-                "Component_[2303614537700606121]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2303614537700606121
-                },
                 "Component_[295756399074028600]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 295756399074028600
@@ -2422,163 +1480,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{CE48905C-E0C7-57BC-A65D-FEA29A20BF80}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_snow.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 }
             }
         },
@@ -2629,163 +1531,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[15031379514475369613]": {
                     "$type": "EditorLockComponent",
@@ -2794,10 +1540,6 @@
                 "Component_[15183822379560953471]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 15183822379560953471
-                },
-                "Component_[17112385175498437426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17112385175498437426
                 },
                 "Component_[18366445350205353132]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -2911,163 +1653,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9420B802-CBDA-5CE3-B6F2-0E19FBF67619}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_double_snow.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[15031379514475369613]": {
                     "$type": "EditorLockComponent",
@@ -3076,10 +1662,6 @@
                 "Component_[15183822379560953471]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 15183822379560953471
-                },
-                "Component_[17112385175498437426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17112385175498437426
                 },
                 "Component_[18366445350205353132]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -3152,12 +1734,7 @@
             "Components": {
                 "Component_[11957677126402435582]": {
                     "$type": "{CA11DA46-29FF-4083-B5F6-E02C3A8C3A3D} EditorCameraComponent",
-                    "Id": 11957677126402435582,
-                    "Controller": {
-                        "Configuration": {
-                            "EditorEntityId": 1075695602995
-                        }
-                    }
+                    "Id": 11957677126402435582
                 },
                 "Component_[12040935607835760311]": {
                     "$type": "EditorEntitySortComponent",
@@ -3188,10 +1765,6 @@
                         }
                     ]
                 },
-                "Component_[16237361815719873944]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16237361815719873944
-                },
                 "Component_[3413238310375761001]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 3413238310375761001
@@ -3220,6 +1793,14 @@
                 "Component_[8777038637049574851]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 8777038637049574851
+                },
+                "FlyCameraInputComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 9366001828934547678,
+                    "m_template": {
+                        "$type": "FlyCameraInputComponent",
+                        "Move Speed": 2.0
+                    }
                 }
             }
         },
@@ -3336,127 +1917,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{779EE343-FC85-517D-8575-DAAAC78C0BA1}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/fire.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1684058372
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1684058372
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1684058372
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1684058372
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1684058372
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1684058372
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1684058372
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1684058372
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1684058372
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1684058372
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1684058372
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1684058372
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1684058372
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1684058372
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1684058372
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1684058372
-                                }
-                            }
-                        ]
-                    ]
-                },
-                "Component_[9605634037037463392]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9605634037037463392
+                    }
                 }
             }
         },
@@ -3533,10 +1994,6 @@
                             4.199049472808838
                         ]
                     }
-                },
-                "Component_[8936564595776733398]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8936564595776733398
                 }
             }
         },
@@ -3618,10 +2075,6 @@
                             88.49292755126953
                         ]
                     }
-                },
-                "Component_[8936564595776733398]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8936564595776733398
                 }
             }
         },
@@ -3703,10 +2156,6 @@
                             77.25325775146484
                         ]
                     }
-                },
-                "Component_[8936564595776733398]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8936564595776733398
                 }
             }
         },
@@ -3801,10 +2250,6 @@
                             -62.71708679199219
                         ]
                     }
-                },
-                "Component_[8936564595776733398]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8936564595776733398
                 }
             }
         },
@@ -3883,10 +2328,6 @@
                             "SortIndex": 1
                         }
                     ]
-                },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
                 },
                 "Component_[7364378514629616014]": {
                     "$type": "EditorEntitySortComponent",
@@ -3982,10 +2423,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[7364378514629616014]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7364378514629616014
@@ -4066,10 +2503,6 @@
                             "SortIndex": 1
                         }
                     ]
-                },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
                 },
                 "Component_[7364378514629616014]": {
                     "$type": "EditorEntitySortComponent",
@@ -4152,10 +2585,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[7364378514629616014]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7364378514629616014
@@ -4236,10 +2665,6 @@
                             "SortIndex": 1
                         }
                     ]
-                },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
                 },
                 "Component_[7364378514629616014]": {
                     "$type": "EditorEntitySortComponent",
@@ -4335,10 +2760,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[7364378514629616014]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7364378514629616014
@@ -4423,10 +2844,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
                 },
                 "Component_[7364378514629616014]": {
                     "$type": "EditorEntitySortComponent",
@@ -4531,10 +2948,6 @@
                         1.3293755054473877
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[7364378514629616014]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7364378514629616014
@@ -4565,10 +2978,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -4632,10 +3041,6 @@
                 "Component_[10399893379885520398]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 10399893379885520398
-                },
-                "Component_[12604042374626956858]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12604042374626956858
                 },
                 "Component_[13164850631023337578]": {
                     "$type": "EditorInspectorComponent",
@@ -4721,163 +3126,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3484795259
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{1978F3D1-D3FA-592C-9CCB-7253A41E47FB}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/winter house_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3484795259
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{1978F3D1-D3FA-592C-9CCB-7253A41E47FB}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/winter house_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3484795259
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{1978F3D1-D3FA-592C-9CCB-7253A41E47FB}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/winter house_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3484795259
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{1978F3D1-D3FA-592C-9CCB-7253A41E47FB}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/winter house_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3484795259
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{1978F3D1-D3FA-592C-9CCB-7253A41E47FB}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/winter house_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3484795259
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{1978F3D1-D3FA-592C-9CCB-7253A41E47FB}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/winter house_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3484795259
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{1978F3D1-D3FA-592C-9CCB-7253A41E47FB}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/winter house_snow.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3484795259
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{1978F3D1-D3FA-592C-9CCB-7253A41E47FB}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/winter house_snow.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3484795259
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3484795259
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3484795259
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3484795259
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3484795259
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3484795259
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3484795259
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3484795259
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[5710031821303871459]": {
                     "$type": "EditorEntityIconComponent",
@@ -4912,214 +3161,59 @@
                 "Component_[14493356997294756208]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 14493356997294756208,
-                    "ChildEntityOrderEntryArray": [
-                        {
-                            "EntityId": "Entity_[435745475891]"
-                        },
-                        {
-                            "EntityId": "Entity_[498564363569]",
-                            "SortIndex": 1
-                        },
-                        {
-                            "EntityId": "Entity_[420667320994]",
-                            "SortIndex": 2
-                        },
-                        {
-                            "EntityId": "Entity_[489974428977]",
-                            "SortIndex": 3
-                        },
-                        {
-                            "EntityId": "Entity_[951141551411]",
-                            "SortIndex": 4
-                        },
-                        {
-                            "EntityId": "Entity_[421254952241]",
-                            "SortIndex": 5
-                        },
-                        {
-                            "EntityId": "Entity_[397099779955]",
-                            "SortIndex": 6
-                        },
-                        {
-                            "EntityId": "Entity_[618823447857]",
-                            "SortIndex": 7
-                        },
-                        {
-                            "EntityId": "Entity_[472794559793]",
-                            "SortIndex": 8
-                        },
-                        {
-                            "EntityId": "Entity_[415763804643]",
-                            "SortIndex": 9
-                        },
-                        {
-                            "EntityId": "Entity_[434139854129]",
-                            "SortIndex": 10
-                        },
-                        {
-                            "EntityId": "Entity_[532924101937]",
-                            "SortIndex": 11
-                        },
-                        {
-                            "EntityId": "Entity_[631708349745]",
-                            "SortIndex": 12
-                        },
-                        {
-                            "EntityId": "Entity_[416959984945]",
-                            "SortIndex": 13
-                        },
-                        {
-                            "EntityId": "Entity_[475893346787]",
-                            "SortIndex": 14
-                        },
-                        {
-                            "EntityId": "Entity_[451319723313]",
-                            "SortIndex": 15
-                        },
-                        {
-                            "EntityId": "Entity_[550103971121]",
-                            "SortIndex": 16
-                        },
-                        {
-                            "EntityId": "Entity_[541514036529]",
-                            "SortIndex": 17
-                        },
-                        {
-                            "EntityId": "Entity_[623118415153]",
-                            "SortIndex": 18
-                        },
-                        {
-                            "EntityId": "Entity_[524334167345]",
-                            "SortIndex": 19
-                        },
-                        {
-                            "EntityId": "Entity_[757868023091]",
-                            "SortIndex": 20
-                        },
-                        {
-                            "EntityId": "Entity_[467303412195]",
-                            "SortIndex": 21
-                        },
-                        {
-                            "EntityId": "Entity_[562988873009]",
-                            "SortIndex": 22
-                        },
-                        {
-                            "EntityId": "Entity_[464204625201]",
-                            "SortIndex": 23
-                        },
-                        {
-                            "EntityId": "Entity_[407173870051]",
-                            "SortIndex": 24
-                        },
-                        {
-                            "EntityId": "Entity_[554398938417]",
-                            "SortIndex": 25
-                        },
-                        {
-                            "EntityId": "Entity_[593053644081]",
-                            "SortIndex": 26
-                        },
-                        {
-                            "EntityId": "Entity_[502859330865]",
-                            "SortIndex": 27
-                        },
-                        {
-                            "EntityId": "Entity_[481384494385]",
-                            "SortIndex": 28
-                        },
-                        {
-                            "EntityId": "Entity_[412077386402]",
-                            "SortIndex": 29
-                        },
-                        {
-                            "EntityId": "Entity_[575873774897]",
-                            "SortIndex": 30
-                        },
-                        {
-                            "EntityId": "Entity_[584463709489]",
-                            "SortIndex": 31
-                        },
-                        {
-                            "EntityId": "Entity_[400154172108]",
-                            "SortIndex": 32
-                        },
-                        {
-                            "EntityId": "Entity_[485679461681]",
-                            "SortIndex": 33
-                        },
-                        {
-                            "EntityId": "Entity_[644593251633]",
-                            "SortIndex": 34
-                        },
-                        {
-                            "EntityId": "Entity_[447024756017]",
-                            "SortIndex": 35
-                        },
-                        {
-                            "EntityId": "Entity_[614528480561]",
-                            "SortIndex": 36
-                        },
-                        {
-                            "EntityId": "Entity_[419192463730]",
-                            "SortIndex": 37
-                        },
-                        {
-                            "EntityId": "Entity_[946846584115]",
-                            "SortIndex": 38
-                        },
-                        {
-                            "EntityId": "Entity_[459909657905]",
-                            "SortIndex": 39
-                        },
-                        {
-                            "EntityId": "Entity_[891012009267]",
-                            "SortIndex": 40
-                        },
-                        {
-                            "EntityId": "Entity_[402878902755]",
-                            "SortIndex": 41
-                        },
-                        {
-                            "EntityId": "Entity_[636003317041]",
-                            "SortIndex": 42
-                        },
-                        {
-                            "EntityId": "Entity_[438434821425]",
-                            "SortIndex": 43
-                        },
-                        {
-                            "EntityId": "Entity_[605938545969]",
-                            "SortIndex": 44
-                        },
-                        {
-                            "EntityId": "Entity_[938256649523]",
-                            "SortIndex": 45
-                        },
-                        {
-                            "EntityId": "Entity_[1135825145139]",
-                            "SortIndex": 46
-                        },
-                        {
-                            "EntityId": "Entity_[511449265457]",
-                            "SortIndex": 47
-                        },
-                        {
-                            "EntityId": "Entity_[942551616819]",
-                            "SortIndex": 48
-                        },
-                        {
-                            "EntityId": "Entity_[744983121203]",
-                            "SortIndex": 49
-                        },
-                        {
-                            "EntityId": "Entity_[674658022705]",
-                            "SortIndex": 50
-                        },
-                        {
-                            "EntityId": "Entity_[678952990001]",
-                            "SortIndex": 51
-                        }
+                    "Child Entity Order": [
+                        "Entity_[435745475891]",
+                        "Entity_[498564363569]",
+                        "Entity_[420667320994]",
+                        "Entity_[489974428977]",
+                        "Entity_[951141551411]",
+                        "Entity_[421254952241]",
+                        "Entity_[397099779955]",
+                        "Entity_[618823447857]",
+                        "Entity_[472794559793]",
+                        "Entity_[415763804643]",
+                        "Entity_[434139854129]",
+                        "Entity_[532924101937]",
+                        "Entity_[631708349745]",
+                        "Entity_[416959984945]",
+                        "Entity_[475893346787]",
+                        "Entity_[451319723313]",
+                        "Entity_[550103971121]",
+                        "Entity_[541514036529]",
+                        "Entity_[623118415153]",
+                        "Entity_[524334167345]",
+                        "Entity_[757868023091]",
+                        "Entity_[467303412195]",
+                        "Entity_[562988873009]",
+                        "Entity_[464204625201]",
+                        "Entity_[407173870051]",
+                        "Entity_[554398938417]",
+                        "Entity_[593053644081]",
+                        "Entity_[502859330865]",
+                        "Entity_[481384494385]",
+                        "Entity_[412077386402]",
+                        "Entity_[575873774897]",
+                        "Entity_[584463709489]",
+                        "Entity_[400154172108]",
+                        "Entity_[485679461681]",
+                        "Entity_[644593251633]",
+                        "Entity_[447024756017]",
+                        "Entity_[614528480561]",
+                        "Entity_[419192463730]",
+                        "Entity_[946846584115]",
+                        "Entity_[459909657905]",
+                        "Entity_[891012009267]",
+                        "Entity_[402878902755]",
+                        "Entity_[636003317041]",
+                        "Entity_[438434821425]",
+                        "Entity_[605938545969]",
+                        "Entity_[938256649523]",
+                        "Entity_[1135825145139]",
+                        "Entity_[511449265457]",
+                        "Entity_[942551616819]",
+                        "Entity_[744983121203]",
+                        "Entity_[674658022705]",
+                        "Entity_[678952990001]"
                     ]
                 },
                 "Component_[15183124544900222183]": {
@@ -5150,10 +3244,6 @@
                 "Component_[5952087034759134145]": {
                     "$type": "EditorLockComponent",
                     "Id": 5952087034759134145
-                },
-                "Component_[7124769840496726761]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7124769840496726761
                 },
                 "Component_[860335504056945556]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -5193,10 +3283,6 @@
                 "Component_[1532572044355155879]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 1532572044355155879
-                },
-                "Component_[15526283528063857461]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15526283528063857461
                 },
                 "Component_[1648160071550017416]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -5306,10 +3392,6 @@
                         "UniformScale": 3.0
                     }
                 },
-                "Component_[17120977349601258796]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17120977349601258796
-                },
                 "Component_[17324902064638518788]": {
                     "$type": "AZ::Render::EditorMeshComponent",
                     "Id": 17324902064638518788,
@@ -5365,299 +3447,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 263032529
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{94DEE8F1-D323-5C68-8C8C-A1F521634327}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3230039519
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B8C26492-7231-5458-8F53-2EE5F139C24D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 263032529
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{94DEE8F1-D323-5C68-8C8C-A1F521634327}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3230039519
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B8C26492-7231-5458-8F53-2EE5F139C24D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 263032529
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{94DEE8F1-D323-5C68-8C8C-A1F521634327}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3230039519
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B8C26492-7231-5458-8F53-2EE5F139C24D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 263032529
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{94DEE8F1-D323-5C68-8C8C-A1F521634327}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3230039519
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B8C26492-7231-5458-8F53-2EE5F139C24D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 263032529
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{94DEE8F1-D323-5C68-8C8C-A1F521634327}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3230039519
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B8C26492-7231-5458-8F53-2EE5F139C24D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 263032529
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{94DEE8F1-D323-5C68-8C8C-A1F521634327}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3230039519
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B8C26492-7231-5458-8F53-2EE5F139C24D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 263032529
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{94DEE8F1-D323-5C68-8C8C-A1F521634327}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3230039519
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B8C26492-7231-5458-8F53-2EE5F139C24D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 263032529
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{94DEE8F1-D323-5C68-8C8C-A1F521634327}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3230039519
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B8C26492-7231-5458-8F53-2EE5F139C24D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy2_badguy2.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 263032529
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3230039519
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 263032529
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3230039519
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 263032529
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3230039519
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 263032529
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3230039519
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 263032529
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3230039519
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 263032529
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3230039519
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 263032529
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3230039519
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 263032529
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3230039519
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[2610533779925521095]": {
                     "$type": "EditorEntitySortComponent",
@@ -5722,10 +3512,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 6833698677520731086
                 },
-                "Component_[6910389716098359255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6910389716098359255
-                },
                 "Component_[7266408583288213651]": {
                     "$type": "AZ::Render::EditorMeshComponent",
                     "Id": 7266408583288213651,
@@ -5755,10 +3541,6 @@
                 "Component_[11886170654507476631]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 11886170654507476631
-                },
-                "Component_[12851832025516500070]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12851832025516500070
                 },
                 "Component_[13560672861893421328]": {
                     "$type": "EditorLockComponent",
@@ -6033,1003 +3815,11 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[5303454561254299632]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 5303454561254299632
-                },
-                "Component_[6216051112958117042]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6216051112958117042
                 },
                 "Component_[7793481442289032302]": {
                     "$type": "EditorEntitySortComponent",
@@ -7153,179 +3943,11 @@
                                 }
                             ]
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{756C5768-71F4-5E9E-B5F8-AB6FA3F9A627}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/tombstone.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{FB2082C5-24F5-5CB0-9E2A-9F71C868A70D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bomb-building1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{FB2082C5-24F5-5CB0-9E2A-9F71C868A70D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bomb-building1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{FB2082C5-24F5-5CB0-9E2A-9F71C868A70D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bomb-building1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{FB2082C5-24F5-5CB0-9E2A-9F71C868A70D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bomb-building1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{FB2082C5-24F5-5CB0-9E2A-9F71C868A70D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bomb-building1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{FB2082C5-24F5-5CB0-9E2A-9F71C868A70D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bomb-building1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{FB2082C5-24F5-5CB0-9E2A-9F71C868A70D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bomb-building1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{FB2082C5-24F5-5CB0-9E2A-9F71C868A70D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bomb-building1.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[4839764330671942449]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 4839764330671942449
-                },
-                "Component_[5082069820044092919]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5082069820044092919
                 },
                 "Component_[5676215311995618123]": {
                     "$type": "EditorVisibilityComponent",
@@ -7407,10 +4029,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 6833698677520731086
                 },
-                "Component_[6910389716098359255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6910389716098359255
-                },
                 "Component_[7266408583288213651]": {
                     "$type": "AZ::Render::EditorMeshComponent",
                     "Id": 7266408583288213651,
@@ -7454,10 +4072,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -7562,299 +4176,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{88B226B5-D139-54FA-979A-1C57938B2DA3}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/snowman1.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3721690861
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 29648280
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3721690861
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 29648280
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3721690861
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 29648280
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3721690861
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 29648280
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3721690861
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 29648280
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3721690861
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 29648280
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3721690861
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 29648280
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3721690861
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 29648280
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3721690861
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 29648280
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3721690861
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 29648280
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3721690861
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 29648280
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3721690861
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 29648280
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3721690861
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 29648280
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3721690861
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 29648280
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3721690861
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 29648280
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3721690861
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 29648280
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[13489335094205509385]": {
                     "$type": "EditorInspectorComponent",
@@ -7923,10 +4245,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 5041987223481545254
                 },
-                "Component_[6083414717584514194]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6083414717584514194
-                },
                 "Component_[6602047889913350897]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 6602047889913350897
@@ -7962,10 +4280,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -8027,10 +4341,6 @@
             "Id": "Entity_[403487451810]",
             "Name": "bomb-building2",
             "Components": {
-                "Component_[10861364681945745344]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10861364681945745344
-                },
                 "Component_[10900184980790952633]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 10900184980790952633,
@@ -8109,123 +4419,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{35E42991-9E2B-5B69-BC14-0BD72B1B1BB7}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/bomb-building2.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[8914809035485963750]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -8245,10 +4439,6 @@
             "Id": "Entity_[406924864191]",
             "Name": "crate",
             "Components": {
-                "Component_[1129253996383983861]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1129253996383983861
-                },
                 "Component_[13615276520401295862]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13615276520401295862
@@ -8351,10 +4541,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -8482,127 +4668,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{47214C9F-35E3-5C53-84A8-ED7EA30A9EDF}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/bomb-building3.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 166548043
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 166548043
-                                }
-                            }
-                        ]
-                    ]
-                },
-                "Component_[17782812271156784449]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17782812271156784449
+                    }
                 },
                 "Component_[2671066524952016327]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -8646,10 +4712,6 @@
                 "Component_[10338601526946638493]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10338601526946638493
-                },
-                "Component_[13566592875745003741]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13566592875745003741
                 },
                 "Component_[16496618572581084586]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -8988,1451 +5050,11 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[5303454561254299632]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 5303454561254299632
-                },
-                "Component_[6216051112958117042]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6216051112958117042
                 },
                 "Component_[7793481442289032302]": {
                     "$type": "EditorEntitySortComponent",
@@ -10483,10 +5105,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -10577,10 +5195,6 @@
                         }
                     ]
                 },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
-                },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2380005729894723115
@@ -10653,299 +5267,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -10986,10 +5308,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -11072,10 +5390,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -11183,10 +5497,6 @@
                             "ShadowFilterMethod": 1
                         }
                     }
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -11515,1423 +5825,11 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3434207421
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color5_7418342490034526397.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3731683679
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color6_9413074402384083295.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[5303454561254299632]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 5303454561254299632
-                },
-                "Component_[6216051112958117042]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6216051112958117042
                 },
                 "Component_[7793481442289032302]": {
                     "$type": "EditorEntitySortComponent",
@@ -12982,10 +5880,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -13063,10 +5957,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -13132,10 +6022,6 @@
                 "Component_[11449737760326032953]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 11449737760326032953
-                },
-                "Component_[14257271630631243255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14257271630631243255
                 },
                 "Component_[15269289709486467123]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -13293,163 +6179,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8D5274B3-DB49-55C1-BDFC-FC79AE2F31D5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8D5274B3-DB49-55C1-BDFC-FC79AE2F31D5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8D5274B3-DB49-55C1-BDFC-FC79AE2F31D5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8D5274B3-DB49-55C1-BDFC-FC79AE2F31D5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8D5274B3-DB49-55C1-BDFC-FC79AE2F31D5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8D5274B3-DB49-55C1-BDFC-FC79AE2F31D5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8D5274B3-DB49-55C1-BDFC-FC79AE2F31D5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8D5274B3-DB49-55C1-BDFC-FC79AE2F31D5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-1.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6085840801547544287]": {
                     "$type": "EditorInspectorComponent",
@@ -13467,10 +6197,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[6414028830046246173]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6414028830046246173
                 }
             }
         },
@@ -13531,10 +6257,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 6833698677520731086
                 },
-                "Component_[6910389716098359255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6910389716098359255
-                },
                 "Component_[7266408583288213651]": {
                     "$type": "AZ::Render::EditorMeshComponent",
                     "Id": 7266408583288213651,
@@ -13560,10 +6282,6 @@
                 "Component_[11449737760326032953]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 11449737760326032953
-                },
-                "Component_[14257271630631243255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14257271630631243255
                 },
                 "Component_[15269289709486467123]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -13721,163 +6439,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{227E18E6-4090-5271-895A-D1A8A07A983E}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{227E18E6-4090-5271-895A-D1A8A07A983E}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{227E18E6-4090-5271-895A-D1A8A07A983E}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{227E18E6-4090-5271-895A-D1A8A07A983E}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{227E18E6-4090-5271-895A-D1A8A07A983E}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{227E18E6-4090-5271-895A-D1A8A07A983E}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{227E18E6-4090-5271-895A-D1A8A07A983E}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{227E18E6-4090-5271-895A-D1A8A07A983E}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-2.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6085840801547544287]": {
                     "$type": "EditorInspectorComponent",
@@ -13895,10 +6457,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[6414028830046246173]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6414028830046246173
                 }
             }
         },
@@ -13934,10 +6492,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
                 },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -14007,299 +6561,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -14381,171 +6643,11 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[459004811423038559]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 459004811423038559
-                },
-                "Component_[4962490268083236442]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4962490268083236442
                 },
                 "Component_[5787176218719659025]": {
                     "$type": "EditorEntitySortComponent",
@@ -14585,10 +6687,6 @@
                 "Component_[11449737760326032953]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 11449737760326032953
-                },
-                "Component_[14257271630631243255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14257271630631243255
                 },
                 "Component_[15269289709486467123]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -14751,163 +6849,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{2606B757-1903-57B0-8453-A38DE89E7B70}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{2606B757-1903-57B0-8453-A38DE89E7B70}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{2606B757-1903-57B0-8453-A38DE89E7B70}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{2606B757-1903-57B0-8453-A38DE89E7B70}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{2606B757-1903-57B0-8453-A38DE89E7B70}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{2606B757-1903-57B0-8453-A38DE89E7B70}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{2606B757-1903-57B0-8453-A38DE89E7B70}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{2606B757-1903-57B0-8453-A38DE89E7B70}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-3.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6085840801547544287]": {
                     "$type": "EditorInspectorComponent",
@@ -14925,10 +6867,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[6414028830046246173]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6414028830046246173
                 }
             }
         },
@@ -14957,10 +6895,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -15057,10 +6991,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -15197,10 +7127,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[3548952105967942507]": {
                     "$type": "EditorNonUniformScaleComponent",
                     "Id": 3548952105967942507,
@@ -15303,163 +7229,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{ACBF2A03-7F10-5008-A9A2-CBD5C3B8DFC2}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{ACBF2A03-7F10-5008-A9A2-CBD5C3B8DFC2}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{ACBF2A03-7F10-5008-A9A2-CBD5C3B8DFC2}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{ACBF2A03-7F10-5008-A9A2-CBD5C3B8DFC2}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{ACBF2A03-7F10-5008-A9A2-CBD5C3B8DFC2}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{ACBF2A03-7F10-5008-A9A2-CBD5C3B8DFC2}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{ACBF2A03-7F10-5008-A9A2-CBD5C3B8DFC2}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3950087183
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{ACBF2A03-7F10-5008-A9A2-CBD5C3B8DFC2}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/island-4.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3950087183
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6085840801547544287]": {
                     "$type": "EditorInspectorComponent",
@@ -15477,10 +7247,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[6414028830046246173]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6414028830046246173
                 }
             }
         },
@@ -15503,10 +7269,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -15646,10 +7408,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[3548952105967942507]": {
                     "$type": "EditorNonUniformScaleComponent",
                     "Id": 3548952105967942507,
@@ -15669,10 +7427,6 @@
             "Id": "Entity_[441598975873]",
             "Name": "crate",
             "Components": {
-                "Component_[1129253996383983861]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1129253996383983861
-                },
                 "Component_[13615276520401295862]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13615276520401295862
@@ -15830,10 +7584,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[3548952105967942507]": {
                     "$type": "EditorNonUniformScaleComponent",
                     "Id": 3548952105967942507,
@@ -15874,10 +7624,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -16030,10 +7776,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[3548952105967942507]": {
                     "$type": "EditorNonUniformScaleComponent",
                     "Id": 3548952105967942507,
@@ -16068,10 +7810,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -16211,10 +7949,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[3548952105967942507]": {
                     "$type": "EditorNonUniformScaleComponent",
                     "Id": 3548952105967942507,
@@ -16262,10 +7996,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
                 },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -16335,299 +8065,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -16647,10 +8085,6 @@
             "Id": "Entity_[458713477603]",
             "Name": "crate",
             "Components": {
-                "Component_[1129253996383983861]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1129253996383983861
-                },
                 "Component_[13615276520401295862]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13615276520401295862
@@ -16753,10 +8187,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -17077,1395 +8507,11 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1401458738
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 600957204
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 396367285
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color7_12683493039182714293.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3220693274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3463463745
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 600957204
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color1_17005643758929305876.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3905978067
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3220693274
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color2_1450722973785252122.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3434207421
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3463463745
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color3_7658822566574834497.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3731683679
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 3905978067
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color4_18406202107487092435.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 396367285
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1749056407
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{713E89AD-2CFD-5A3D-A6DB-66407AA04E61}",
-                                    "subId": 1749056407
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/badguy_badguy_color8_12022483056691542935.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2985691893
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1931402267
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1401458738
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 600957204
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3220693274
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3463463745
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3905978067
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3434207421
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3731683679
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 396367285
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1749056407
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2985691893
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1931402267
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[5303454561254299632]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 5303454561254299632
-                },
-                "Component_[6216051112958117042]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6216051112958117042
                 },
                 "Component_[7793481442289032302]": {
                     "$type": "EditorEntitySortComponent",
@@ -18510,10 +8556,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -18598,10 +8640,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -18692,10 +8730,6 @@
                         }
                     ]
                 },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
-                },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2380005729894723115
@@ -18763,299 +8797,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -19108,10 +8850,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 17073904121781876957
                 },
-                "Component_[289362113867985140]": {
-                    "$type": "SelectionComponent",
-                    "Id": 289362113867985140
-                },
                 "Component_[506775791971833605]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 506775791971833605
@@ -19159,163 +8897,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[8988094265988613553]": {
                     "$type": "EditorInspectorComponent",
@@ -19359,10 +8941,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -19447,10 +9025,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -19541,10 +9115,6 @@
                         }
                     ]
                 },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
-                },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2380005729894723115
@@ -19612,299 +9182,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -20000,10 +9278,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[3548952105967942507]": {
                     "$type": "EditorNonUniformScaleComponent",
                     "Id": 3548952105967942507,
@@ -20038,10 +9312,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -20126,10 +9396,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -20228,10 +9494,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -20329,10 +9591,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -20423,10 +9681,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -20519,10 +9773,6 @@
                         }
                     ]
                 },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
-                },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2380005729894723115
@@ -20591,299 +9841,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -20918,10 +9876,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -21014,10 +9968,6 @@
                         }
                     ]
                 },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
-                },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2380005729894723115
@@ -21085,299 +10035,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -21412,10 +10070,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -21508,10 +10162,6 @@
                         }
                     ]
                 },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
-                },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2380005729894723115
@@ -21585,299 +10235,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -21912,10 +10270,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -22000,10 +10354,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -22102,10 +10452,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -22196,10 +10542,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -22292,10 +10634,6 @@
                         }
                     ]
                 },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
-                },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2380005729894723115
@@ -22363,299 +10701,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4189049-DFCB-58BA-90BC-49EB34E7EC54}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{61D7D49D-0AD9-532B-BEB7-365E28D81179}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4189049-DFCB-58BA-90BC-49EB34E7EC54}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{61D7D49D-0AD9-532B-BEB7-365E28D81179}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4189049-DFCB-58BA-90BC-49EB34E7EC54}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{61D7D49D-0AD9-532B-BEB7-365E28D81179}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4189049-DFCB-58BA-90BC-49EB34E7EC54}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{61D7D49D-0AD9-532B-BEB7-365E28D81179}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4189049-DFCB-58BA-90BC-49EB34E7EC54}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{61D7D49D-0AD9-532B-BEB7-365E28D81179}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4189049-DFCB-58BA-90BC-49EB34E7EC54}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{61D7D49D-0AD9-532B-BEB7-365E28D81179}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4189049-DFCB-58BA-90BC-49EB34E7EC54}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{61D7D49D-0AD9-532B-BEB7-365E28D81179}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4189049-DFCB-58BA-90BC-49EB34E7EC54}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight4.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{61D7D49D-0AD9-532B-BEB7-365E28D81179}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box2.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -22682,10 +10728,6 @@
                 "Component_[10338601526946638493]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10338601526946638493
-                },
-                "Component_[13566592875745003741]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13566592875745003741
                 },
                 "Component_[16496618572581084586]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -22771,10 +10813,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -22844,10 +10882,6 @@
                 "Component_[10338601526946638493]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10338601526946638493
-                },
-                "Component_[13566592875745003741]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13566592875745003741
                 },
                 "Component_[16496618572581084586]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -22946,10 +10980,6 @@
                         }
                     ]
                 },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
-                },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2380005729894723115
@@ -23017,299 +11047,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -23332,10 +11070,6 @@
                 "Component_[10469292298965063108]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10469292298965063108
-                },
-                "Component_[13973449978014623861]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13973449978014623861
                 },
                 "Component_[14757121611348694422]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -23417,10 +11151,6 @@
                 "Component_[10469292298965063108]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10469292298965063108
-                },
-                "Component_[13973449978014623861]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13973449978014623861
                 },
                 "Component_[14757121611348694422]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -23515,10 +11245,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -23584,10 +11310,6 @@
                 "Component_[10469292298965063108]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10469292298965063108
-                },
-                "Component_[13973449978014623861]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13973449978014623861
                 },
                 "Component_[14757121611348694422]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -23695,10 +11417,6 @@
                         }
                     ]
                 },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
-                },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2380005729894723115
@@ -23772,299 +11490,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -24084,10 +11510,6 @@
             "Id": "Entity_[581774363955]",
             "Name": "plane part",
             "Components": {
-                "Component_[11154239876703078602]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11154239876703078602
-                },
                 "Component_[11406005167986318229]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 11406005167986318229
@@ -24185,10 +11607,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -24251,10 +11669,6 @@
             "Id": "Entity_[586069331251]",
             "Name": "plane part",
             "Components": {
-                "Component_[11154239876703078602]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11154239876703078602
-                },
                 "Component_[11406005167986318229]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 11406005167986318229
@@ -24336,10 +11750,6 @@
             "Id": "Entity_[590364298547]",
             "Name": "plane part",
             "Components": {
-                "Component_[11154239876703078602]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11154239876703078602
-                },
                 "Component_[11406005167986318229]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 11406005167986318229
@@ -24442,10 +11852,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -24567,10 +11973,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 7639958093248482246
                 },
-                "Component_[8508657902148588813]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8508657902148588813
-                },
                 "Component_[9118689671144946530]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 9118689671144946530,
@@ -24678,10 +12080,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 6833698677520731086
                 },
-                "Component_[6910389716098359255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6910389716098359255
-                },
                 "Component_[7266408583288213651]": {
                     "$type": "AZ::Render::EditorMeshComponent",
                     "Id": 7266408583288213651,
@@ -24704,10 +12102,6 @@
             "Id": "Entity_[598954233139]",
             "Name": "plane part",
             "Components": {
-                "Component_[11154239876703078602]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11154239876703078602
-                },
                 "Component_[11406005167986318229]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 11406005167986318229
@@ -24818,10 +12212,6 @@
                         }
                     ]
                 },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
-                },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2380005729894723115
@@ -24889,299 +12279,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -25201,10 +12299,6 @@
             "Id": "Entity_[603249200435]",
             "Name": "plane blades",
             "Components": {
-                "Component_[12440952205198940357]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12440952205198940357
-                },
                 "Component_[15263932950388798522]": {
                     "$type": "AZ::Render::EditorMeshComponent",
                     "Id": 15263932950388798522,
@@ -25296,10 +12390,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -25396,10 +12486,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 14975403534159893633
                 },
-                "Component_[16783640704661680372]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16783640704661680372
-                },
                 "Component_[2648463403049368183]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 2648463403049368183
@@ -25477,10 +12563,6 @@
                         }
                     ]
                 },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
-                },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2380005729894723115
@@ -25548,299 +12630,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -25875,10 +12665,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -25963,10 +12749,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -26065,10 +12847,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -26166,10 +12944,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -26261,10 +13035,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -26342,10 +13112,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -26438,10 +13204,6 @@
                         }
                     ]
                 },
-                "Component_[16412814634510681692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16412814634510681692
-                },
                 "Component_[2380005729894723115]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2380005729894723115
@@ -26515,299 +13277,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1543722085
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{772E732B-7D23-5FB7-8DC8-D0B29B7A5788}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3562519815
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{EA447E4E-F7F6-5EFF-A0C0-061D13931C89}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/starlight-yellow_starlight_box.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1543722085
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3562519815
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[6886129215438740678]": {
                     "$type": "EditorLockComponent",
@@ -26895,171 +13365,11 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{6856B130-A442-5DC3-BDAE-8A23A1885B63}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/siderweb.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[459004811423038559]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 459004811423038559
-                },
-                "Component_[4962490268083236442]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4962490268083236442
                 },
                 "Component_[5787176218719659025]": {
                     "$type": "EditorEntitySortComponent",
@@ -27117,167 +13427,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{33DEF398-0393-59E4-AF94-F4554F57F31F}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{33DEF398-0393-59E4-AF94-F4554F57F31F}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{33DEF398-0393-59E4-AF94-F4554F57F31F}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{33DEF398-0393-59E4-AF94-F4554F57F31F}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{33DEF398-0393-59E4-AF94-F4554F57F31F}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{33DEF398-0393-59E4-AF94-F4554F57F31F}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{33DEF398-0393-59E4-AF94-F4554F57F31F}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level3.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{33DEF398-0393-59E4-AF94-F4554F57F31F}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level3.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ]
-                    ]
-                },
-                "Component_[11886744082463317273]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11886744082463317273
+                    }
                 },
                 "Component_[14604022659790719993]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -27372,10 +13522,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10338601526946638493
                 },
-                "Component_[13566592875745003741]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13566592875745003741
-                },
                 "Component_[16496618572581084586]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 16496618572581084586
@@ -27452,10 +13598,6 @@
                 "Component_[11449737760326032953]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 11449737760326032953
-                },
-                "Component_[14257271630631243255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14257271630631243255
                 },
                 "Component_[15269289709486467123]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -27624,10 +13766,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[3548952105967942507]": {
                     "$type": "EditorNonUniformScaleComponent",
                     "Id": 3548952105967942507,
@@ -27724,28 +13862,7 @@
                 },
                 "Component_[2678321763164293000]": {
                     "$type": "EditorMaterialComponent",
-                    "Id": 2678321763164293000,
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 2212022979
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2212022979
-                                }
-                            }
-                        ]
-                    ]
-                },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
+                    "Id": 2678321763164293000
                 },
                 "Component_[3548952105967942507]": {
                     "$type": "EditorNonUniformScaleComponent",
@@ -27824,10 +13941,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3831635678742189323
                 },
-                "Component_[5373831303978586891]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5373831303978586891
-                },
                 "Component_[7070803809974593320]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 7070803809974593320
@@ -27867,10 +13980,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -27990,10 +14099,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3831635678742189323
                 },
-                "Component_[5373831303978586891]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5373831303978586891
-                },
                 "Component_[7070803809974593320]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 7070803809974593320
@@ -28032,10 +14137,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -28155,10 +14256,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3831635678742189323
                 },
-                "Component_[5373831303978586891]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5373831303978586891
-                },
                 "Component_[7070803809974593320]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 7070803809974593320
@@ -28245,171 +14342,11 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C352290A-6781-5A45-BEDC-B5BF5890340C}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bigredx.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C352290A-6781-5A45-BEDC-B5BF5890340C}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bigredx.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C352290A-6781-5A45-BEDC-B5BF5890340C}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bigredx.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C352290A-6781-5A45-BEDC-B5BF5890340C}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bigredx.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C352290A-6781-5A45-BEDC-B5BF5890340C}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bigredx.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C352290A-6781-5A45-BEDC-B5BF5890340C}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bigredx.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C352290A-6781-5A45-BEDC-B5BF5890340C}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bigredx.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1577823416
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C352290A-6781-5A45-BEDC-B5BF5890340C}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bigredx.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1577823416
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[459004811423038559]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 459004811423038559
-                },
-                "Component_[4962490268083236442]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4962490268083236442
                 },
                 "Component_[5787176218719659025]": {
                     "$type": "EditorEntitySortComponent",
@@ -28510,10 +14447,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3831635678742189323
                 },
-                "Component_[5373831303978586891]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5373831303978586891
-                },
                 "Component_[7070803809974593320]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 7070803809974593320
@@ -28574,10 +14507,6 @@
                         }
                     }
                 },
-                "Component_[3711755429127490775]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3711755429127490775
-                },
                 "Component_[400344737824241292]": {
                     "$type": "EditorLockComponent",
                     "Id": 400344737824241292
@@ -28623,123 +14552,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{FD014BA6-B184-5A47-A1D0-C5BBB1A429E0}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/tank body-top.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[8750216404644244478]": {
                     "$type": "EditorEntitySortComponent",
@@ -28766,10 +14579,6 @@
                             0.8799601197242737
                         ]
                     }
-                },
-                "Component_[1456750267139437134]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1456750267139437134
                 },
                 "Component_[14711258766175184385]": {
                     "$type": "EditorEntityIconComponent",
@@ -28803,299 +14612,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{DAAAFD6E-2EEC-581B-B42F-4F14509B7429}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/tank body.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3637064706
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3637064706
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[18315793806885228261]": {
                     "$type": "EditorInspectorComponent",
@@ -29152,10 +14669,6 @@
                 "Component_[10697832770633054053]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10697832770633054053
-                },
-                "Component_[12823222752587759994]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12823222752587759994
                 },
                 "Component_[13013260655480247946]": {
                     "$type": "EditorInspectorComponent",
@@ -29238,10 +14751,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10697832770633054053
                 },
-                "Component_[12823222752587759994]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12823222752587759994
-                },
                 "Component_[13013260655480247946]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 13013260655480247946,
@@ -29317,10 +14826,6 @@
                 "Component_[10697832770633054053]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10697832770633054053
-                },
-                "Component_[12823222752587759994]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12823222752587759994
                 },
                 "Component_[13013260655480247946]": {
                     "$type": "EditorInspectorComponent",
@@ -29465,10 +14970,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 6833698677520731086
                 },
-                "Component_[6910389716098359255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6910389716098359255
-                },
                 "Component_[7266408583288213651]": {
                     "$type": "AZ::Render::EditorMeshComponent",
                     "Id": 7266408583288213651,
@@ -29561,10 +15062,6 @@
                 "Component_[6833698677520731086]": {
                     "$type": "EditorLockComponent",
                     "Id": 6833698677520731086
-                },
-                "Component_[6910389716098359255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6910389716098359255
                 },
                 "Component_[7266408583288213651]": {
                     "$type": "AZ::Render::EditorMeshComponent",
@@ -29659,10 +15156,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 6833698677520731086
                 },
-                "Component_[6910389716098359255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6910389716098359255
-                },
                 "Component_[7266408583288213651]": {
                     "$type": "AZ::Render::EditorMeshComponent",
                     "Id": 7266408583288213651,
@@ -29755,10 +15248,6 @@
                 "Component_[6833698677520731086]": {
                     "$type": "EditorLockComponent",
                     "Id": 6833698677520731086
-                },
-                "Component_[6910389716098359255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6910389716098359255
                 },
                 "Component_[7266408583288213651]": {
                     "$type": "AZ::Render::EditorMeshComponent",
@@ -29853,10 +15342,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 6833698677520731086
                 },
-                "Component_[6910389716098359255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6910389716098359255
-                },
                 "Component_[7266408583288213651]": {
                     "$type": "AZ::Render::EditorMeshComponent",
                     "Id": 7266408583288213651,
@@ -29950,10 +15435,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 6833698677520731086
                 },
-                "Component_[6910389716098359255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6910389716098359255
-                },
                 "Component_[7266408583288213651]": {
                     "$type": "AZ::Render::EditorMeshComponent",
                     "Id": 7266408583288213651,
@@ -29997,167 +15478,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8175DBAB-1C61-5C90-B156-D3ECAD9C35D0}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign_level1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8175DBAB-1C61-5C90-B156-D3ECAD9C35D0}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign_level1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8175DBAB-1C61-5C90-B156-D3ECAD9C35D0}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign_level1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8175DBAB-1C61-5C90-B156-D3ECAD9C35D0}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign_level1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8175DBAB-1C61-5C90-B156-D3ECAD9C35D0}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign_level1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8175DBAB-1C61-5C90-B156-D3ECAD9C35D0}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign_level1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8175DBAB-1C61-5C90-B156-D3ECAD9C35D0}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign_level1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{8175DBAB-1C61-5C90-B156-D3ECAD9C35D0}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign_level1.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ]
-                    ]
-                },
-                "Component_[11886744082463317273]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11886744082463317273
+                    }
                 },
                 "Component_[14604022659790719993]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -30260,10 +15581,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -30344,167 +15661,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4DE17C1-A475-5BDF-84E8-AA85DC6A1305}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4DE17C1-A475-5BDF-84E8-AA85DC6A1305}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4DE17C1-A475-5BDF-84E8-AA85DC6A1305}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4DE17C1-A475-5BDF-84E8-AA85DC6A1305}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4DE17C1-A475-5BDF-84E8-AA85DC6A1305}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4DE17C1-A475-5BDF-84E8-AA85DC6A1305}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4DE17C1-A475-5BDF-84E8-AA85DC6A1305}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level2.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3101748943
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{D4DE17C1-A475-5BDF-84E8-AA85DC6A1305}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/signs_sign_level2.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3101748943
-                                }
-                            }
-                        ]
-                    ]
-                },
-                "Component_[11886744082463317273]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11886744082463317273
+                    }
                 },
                 "Component_[14604022659790719993]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -30590,10 +15747,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10469292298965063108
                 },
-                "Component_[13973449978014623861]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13973449978014623861
-                },
                 "Component_[14757121611348694422]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 14757121611348694422
@@ -30619,163 +15772,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 4161264669
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B69319BC-458C-544E-AEC1-809E726C6877}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bridge_white.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 4161264669
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B69319BC-458C-544E-AEC1-809E726C6877}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bridge_white.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 4161264669
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B69319BC-458C-544E-AEC1-809E726C6877}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bridge_white.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 4161264669
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B69319BC-458C-544E-AEC1-809E726C6877}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bridge_white.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 4161264669
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B69319BC-458C-544E-AEC1-809E726C6877}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bridge_white.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 4161264669
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B69319BC-458C-544E-AEC1-809E726C6877}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bridge_white.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 4161264669
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B69319BC-458C-544E-AEC1-809E726C6877}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bridge_white.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 4161264669
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{B69319BC-458C-544E-AEC1-809E726C6877}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/bridge_white.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 4161264669
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 4161264669
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 4161264669
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 4161264669
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 4161264669
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 4161264669
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 4161264669
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 4161264669
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[16644450513837145058]": {
                     "$type": "EditorVisibilityComponent",
@@ -30905,10 +15902,6 @@
                         }
                     }
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -31015,10 +16008,6 @@
                         "UniformScale": 1.5
                     }
                 },
-                "Component_[4231852200983833113]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4231852200983833113
-                },
                 "Component_[461183629654886443]": {
                     "$type": "EditorLockComponent",
                     "Id": 461183629654886443
@@ -31099,10 +16088,6 @@
                         ],
                         "UniformScale": 1.5
                     }
-                },
-                "Component_[4231852200983833113]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4231852200983833113
                 },
                 "Component_[461183629654886443]": {
                     "$type": "EditorLockComponent",
@@ -31185,10 +16170,6 @@
                         "UniformScale": 1.5
                     }
                 },
-                "Component_[4231852200983833113]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4231852200983833113
-                },
                 "Component_[461183629654886443]": {
                     "$type": "EditorLockComponent",
                     "Id": 461183629654886443
@@ -31269,10 +16250,6 @@
                         ],
                         "UniformScale": 1.5
                     }
-                },
-                "Component_[4231852200983833113]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4231852200983833113
                 },
                 "Component_[461183629654886443]": {
                     "$type": "EditorLockComponent",
@@ -31355,10 +16332,6 @@
                         "UniformScale": 1.5
                     }
                 },
-                "Component_[4231852200983833113]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4231852200983833113
-                },
                 "Component_[461183629654886443]": {
                     "$type": "EditorLockComponent",
                     "Id": 461183629654886443
@@ -31440,10 +16413,6 @@
                         "UniformScale": 1.5
                     }
                 },
-                "Component_[4231852200983833113]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4231852200983833113
-                },
                 "Component_[461183629654886443]": {
                     "$type": "EditorLockComponent",
                     "Id": 461183629654886443
@@ -31482,387 +16451,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{FCA9EBC1-5169-5438-8D51-92FB9149A3D7}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/farmhouse.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[13294619088994689097]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -31939,10 +16528,6 @@
                 "Component_[8101630896449284040]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 8101630896449284040
-                },
-                "Component_[9942745378276427175]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9942745378276427175
                 }
             }
         },
@@ -31953,10 +16538,6 @@
                 "Component_[13882941514471703569]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13882941514471703569
-                },
-                "Component_[14040843895149861610]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14040843895149861610
                 },
                 "Component_[15571093598115690126]": {
                     "$type": "EditorInspectorComponent",
@@ -32029,299 +16610,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{27428E0F-83C6-56E0-AF44-FDE1372E5D00}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/windmill base.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1962353560
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2416604718
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1224545875
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1962353560
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2416604718
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1224545875
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[3379320530815702813]": {
                     "$type": "EditorEntitySortComponent",
@@ -32371,10 +16660,6 @@
                         ],
                         "UniformScale": 1.25
                     }
-                },
-                "Component_[11365203532204175959]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11365203532204175959
                 },
                 "Component_[11881322292957092240]": {
                     "$type": "AZ::Render::EditorMeshComponent",
@@ -32450,299 +16735,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{B75191D0-B7B0-5C21-A3B9-F42BBD320B7B}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/windmill blade.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2081885851
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2081885851
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2081885851
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2081885851
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2081885851
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2081885851
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2081885851
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 67876810
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 777840583
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2081885851
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2081885851
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2081885851
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2081885851
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2081885851
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2081885851
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2081885851
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2081885851
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 67876810
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 777840583
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2081885851
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 }
             }
         },
@@ -32816,10 +16809,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[7364378514629616014]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7364378514629616014
@@ -32833,10 +16822,6 @@
                 "Component_[11449737760326032953]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 11449737760326032953
-                },
-                "Component_[14257271630631243255]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14257271630631243255
                 },
                 "Component_[15269289709486467123]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -32981,10 +16966,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[7364378514629616014]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7364378514629616014
@@ -33065,10 +17046,6 @@
                             "SortIndex": 1
                         }
                     ]
-                },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
                 },
                 "Component_[7364378514629616014]": {
                     "$type": "EditorEntitySortComponent",
@@ -33156,10 +17133,6 @@
                         }
                     ]
                 },
-                "Component_[3250168505171858554]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3250168505171858554
-                },
                 "Component_[3548952105967942507]": {
                     "$type": "EditorNonUniformScaleComponent",
                     "Id": 3548952105967942507,
@@ -33182,10 +17155,6 @@
                 "Component_[10697832770633054053]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10697832770633054053
-                },
-                "Component_[12823222752587759994]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12823222752587759994
                 },
                 "Component_[13013260655480247946]": {
                     "$type": "EditorInspectorComponent",
@@ -33280,10 +17249,6 @@
                 "Component_[10697832770633054053]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10697832770633054053
-                },
-                "Component_[12823222752587759994]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12823222752587759994
                 },
                 "Component_[13013260655480247946]": {
                     "$type": "EditorInspectorComponent",
@@ -33408,123 +17373,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{BA422732-B70B-51C9-963B-3BF371D94DB6}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/tree 2branches_standard.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[15031379514475369613]": {
                     "$type": "EditorLockComponent",
@@ -33533,10 +17382,6 @@
                 "Component_[15183822379560953471]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 15183822379560953471
-                },
-                "Component_[17112385175498437426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17112385175498437426
                 },
                 "Component_[18366445350205353132]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -33627,10 +17472,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 15752513506849964945
                 },
-                "Component_[2303614537700606121]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2303614537700606121
-                },
                 "Component_[295756399074028600]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 295756399074028600
@@ -33693,163 +17534,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 }
             }
         },
@@ -33902,10 +17587,6 @@
                 "Component_[15752513506849964945]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 15752513506849964945
-                },
-                "Component_[2303614537700606121]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2303614537700606121
                 },
                 "Component_[295756399074028600]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -33975,163 +17656,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 262344980
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{C5D07005-2265-57C6-9AD5-71E2C2E29E4D}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 1branches_standard.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 262344980
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 }
             }
         },
@@ -34181,163 +17706,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{BA422732-B70B-51C9-963B-3BF371D94DB6}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{BA422732-B70B-51C9-963B-3BF371D94DB6}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{BA422732-B70B-51C9-963B-3BF371D94DB6}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{BA422732-B70B-51C9-963B-3BF371D94DB6}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{BA422732-B70B-51C9-963B-3BF371D94DB6}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{BA422732-B70B-51C9-963B-3BF371D94DB6}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{BA422732-B70B-51C9-963B-3BF371D94DB6}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_standard.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 779471969
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{BA422732-B70B-51C9-963B-3BF371D94DB6}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/tree 2branches_standard.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 779471969
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[15031379514475369613]": {
                     "$type": "EditorLockComponent",
@@ -34346,10 +17715,6 @@
                 "Component_[15183822379560953471]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 15183822379560953471
-                },
-                "Component_[17112385175498437426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17112385175498437426
                 },
                 "Component_[18366445350205353132]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -34441,163 +17806,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[1110170058701487428]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -34669,10 +17878,6 @@
                         }
                     ]
                 },
-                "Component_[757529806437253805]": {
-                    "$type": "SelectionComponent",
-                    "Id": 757529806437253805
-                },
                 "Component_[7630778392762799172]": {
                     "$type": "EditorLockComponent",
                     "Id": 7630778392762799172
@@ -34683,10 +17888,6 @@
             "Id": "Entity_[878127107379]",
             "Name": "mushroom2",
             "Components": {
-                "Component_[10172284883533565469]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10172284883533565469
-                },
                 "Component_[10598689044837075330]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10598689044837075330
@@ -34778,211 +17979,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{25F80F6B-4290-5883-A630-9B25FFE327AA}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/mushroom2.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 }
             }
         },
@@ -35011,10 +18008,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -35076,10 +18069,6 @@
             "Id": "Entity_[895306976563]",
             "Name": "mushroom2",
             "Components": {
-                "Component_[10172284883533565469]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10172284883533565469
-                },
                 "Component_[10598689044837075330]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10598689044837075330
@@ -35176,211 +18165,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{25F80F6B-4290-5883-A630-9B25FFE327AA}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/mushroom2.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 }
             }
         },
@@ -35409,163 +18194,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[1110170058701487428]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -35637,10 +18266,6 @@
                         }
                     ]
                 },
-                "Component_[757529806437253805]": {
-                    "$type": "SelectionComponent",
-                    "Id": 757529806437253805
-                },
                 "Component_[7630778392762799172]": {
                     "$type": "EditorLockComponent",
                     "Id": 7630778392762799172
@@ -35651,10 +18276,6 @@
             "Id": "Entity_[903896911155]",
             "Name": "mushroom2",
             "Components": {
-                "Component_[10172284883533565469]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10172284883533565469
-                },
                 "Component_[10598689044837075330]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10598689044837075330
@@ -35764,211 +18385,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{25F80F6B-4290-5883-A630-9B25FFE327AA}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/mushroom2.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 1174910300
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3865422619
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 1174910300
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3865422619
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 }
             }
         },
@@ -35997,163 +18414,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3863368699
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{9C4E017C-48D8-51CD-8912-9A4654E686B5}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/mushroom1.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3863368699
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[1110170058701487428]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -36230,10 +18491,6 @@
                         }
                     ]
                 },
-                "Component_[757529806437253805]": {
-                    "$type": "SelectionComponent",
-                    "Id": 757529806437253805
-                },
                 "Component_[7630778392762799172]": {
                     "$type": "EditorLockComponent",
                     "Id": 7630778392762799172
@@ -36263,10 +18520,6 @@
                 "Component_[17283022018538282177]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 17283022018538282177
-                },
-                "Component_[17581230500650870061]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17581230500650870061
                 },
                 "Component_[3353062159255613057]": {
                     "$type": "EditorInspectorComponent",
@@ -36305,211 +18558,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{AED4FE19-ACED-5A8C-9861-3BEC79C9E6B1}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/o3de-sign2.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3801545586
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3801545586
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3801545586
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3801545586
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3801545586
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3801545586
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3801545586
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 902256226
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 3801545586
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3801545586
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3801545586
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3801545586
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3801545586
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3801545586
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3801545586
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3801545586
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 902256226
-                                }
-                            },
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 3801545586
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[754852479357947774]": {
                     "$type": "AZ::Render::EditorMeshComponent",
@@ -36639,10 +18688,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 1850448978260504044
                 },
-                "Component_[54549335270592059]": {
-                    "$type": "SelectionComponent",
-                    "Id": 54549335270592059
-                },
                 "Component_[7530524279726189916]": {
                     "$type": "EditorLockComponent",
                     "Id": 7530524279726189916
@@ -36668,163 +18713,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 2255756995
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{4FFAAF3B-528A-5EE8-A78E-52091FB37590}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign-backlight.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2255756995
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{4FFAAF3B-528A-5EE8-A78E-52091FB37590}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign-backlight.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2255756995
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{4FFAAF3B-528A-5EE8-A78E-52091FB37590}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign-backlight.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2255756995
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{4FFAAF3B-528A-5EE8-A78E-52091FB37590}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign-backlight.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2255756995
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{4FFAAF3B-528A-5EE8-A78E-52091FB37590}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign-backlight.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2255756995
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{4FFAAF3B-528A-5EE8-A78E-52091FB37590}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign-backlight.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2255756995
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{4FFAAF3B-528A-5EE8-A78E-52091FB37590}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign-backlight.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2255756995
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{4FFAAF3B-528A-5EE8-A78E-52091FB37590}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/sign-backlight.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2255756995
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2255756995
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2255756995
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2255756995
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2255756995
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2255756995
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2255756995
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2255756995
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[9232390787244723900]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -36856,10 +18745,6 @@
                 "Component_[12853017703306734296]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
-                },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
                 },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
@@ -36942,10 +18827,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -37027,10 +18908,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -37111,10 +18988,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12853017703306734296
                 },
-                "Component_[14676903636088758323]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14676903636088758323
-                },
                 "Component_[15785473599508150979]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15785473599508150979
@@ -37177,10 +19050,6 @@
                 "Component_[10469292298965063108]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10469292298965063108
-                },
-                "Component_[13973449978014623861]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13973449978014623861
                 },
                 "Component_[14757121611348694422]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -37259,10 +19128,6 @@
             "Id": "Entity_[964026453299]",
             "Name": "crate",
             "Components": {
-                "Component_[1129253996383983861]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1129253996383983861
-                },
                 "Component_[13615276520401295862]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13615276520401295862
@@ -37344,10 +19209,6 @@
             "Id": "Entity_[968321420595]",
             "Name": "crate",
             "Components": {
-                "Component_[1129253996383983861]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1129253996383983861
-                },
                 "Component_[13615276520401295862]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13615276520401295862
@@ -37429,10 +19290,6 @@
             "Id": "Entity_[972616387891]",
             "Name": "crate",
             "Components": {
-                "Component_[1129253996383983861]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1129253996383983861
-                },
                 "Component_[13615276520401295862]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13615276520401295862
@@ -37547,10 +19404,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 17073904121781876957
                 },
-                "Component_[289362113867985140]": {
-                    "$type": "SelectionComponent",
-                    "Id": 289362113867985140
-                },
                 "Component_[506775791971833605]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 506775791971833605
@@ -37598,163 +19451,7 @@
                                 }
                             ]
                         }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2837203274
-                            },
-                            "materialAsset": {
-                                "assetId": {
-                                    "guid": "{F12FCC80-E3CA-58D8-B656-280B22BDA567}"
-                                },
-                                "assetHint": "joshuas-assets/gamejam2021/golden gnome.azmaterial"
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2837203274
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[8988094265988613553]": {
                     "$type": "EditorInspectorComponent",
@@ -37812,10 +19509,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 1562949762498804574
                 },
-                "Component_[1569754468807245361]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1569754468807245361
-                },
                 "Component_[18023540348127863762]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 18023540348127863762,
@@ -37865,123 +19558,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{096F7CAB-CCFD-51E0-9B1F-9FA12CE6D6BF}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/cloud.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[928050064049424887]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -38030,10 +19607,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 1562949762498804574
                 },
-                "Component_[1569754468807245361]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1569754468807245361
-                },
                 "Component_[18023540348127863762]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 18023540348127863762,
@@ -38083,123 +19656,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{096F7CAB-CCFD-51E0-9B1F-9FA12CE6D6BF}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/cloud.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[928050064049424887]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -38254,10 +19711,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 1562949762498804574
                 },
-                "Component_[1569754468807245361]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1569754468807245361
-                },
                 "Component_[18023540348127863762]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 18023540348127863762,
@@ -38307,123 +19760,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{096F7CAB-CCFD-51E0-9B1F-9FA12CE6D6BF}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/cloud.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[928050064049424887]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -38478,10 +19815,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 1562949762498804574
                 },
-                "Component_[1569754468807245361]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1569754468807245361
-                },
                 "Component_[18023540348127863762]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 18023540348127863762,
@@ -38531,123 +19864,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{096F7CAB-CCFD-51E0-9B1F-9FA12CE6D6BF}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/cloud.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[928050064049424887]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -38702,10 +19919,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 1562949762498804574
                 },
-                "Component_[1569754468807245361]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1569754468807245361
-                },
                 "Component_[18023540348127863762]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 18023540348127863762,
@@ -38755,123 +19968,7 @@
                                 }
                             }
                         }
-                    },
-                    "defaultMaterialSlot": {
-                        "materialAsset": {
-                            "assetId": {
-                                "guid": "{096F7CAB-CCFD-51E0-9B1F-9FA12CE6D6BF}"
-                            },
-                            "assetHint": "joshuas-assets/gamejam2021/cloud.azmaterial"
-                        }
-                    },
-                    "materialSlots": [
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        },
-                        {
-                            "id": {
-                                "materialSlotStableId": 2071441547
-                            }
-                        }
-                    ],
-                    "materialSlotsByLod": [
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ],
-                        [
-                            {
-                                "id": {
-                                    "lodIndex": 0,
-                                    "materialSlotStableId": 2071441547
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 },
                 "Component_[928050064049424887]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 These gnomes have come into our world and stolen all our gold. They thought they could hide it where no one would ever find it. But we've found their home. Will you help us sneak into their world and get our gold back? You have to be careful though, these gnomes are clever and left traps for you everywhere. They also don't appear to be gone for long, so be back before the time runs out because at this point, Gnome-bodys home.
 
-*The does not have interaction besides camera movements for now*
+*This project does not have interaction besides camera movements for now*
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,35 @@
-## O3DE Gamejam Project - Gnomebody's Home
-### By Joshua Rainbolt
+## Gnomebody's Home (By Joshua Rainbolt)
 
-#### Overview
-Gnomebodys home is a O3DE game jam project that I created to test the user experience of O3DE. As a UX designer at Amazon we believe in the concept of dogfooding. To put ourselves in our customers place and see how we feel. This ability to understand how our customers experience our software is important part of making great software. It's kind of like method acting, except a little less concerning as a spectator. As UX designers, we spend a lot of time talking to customers, however the ability to actually feel their pain points really changes our perception of the experience. It helps locate those repetitive behaviors or pesky notifications that customers report as annyoying. So the O3DE UX team does just that. For one week annually, we take our product and try to make something fun we can share with the community even if the outcome is a bit corky and playful. We spend our time trying to make a new game but our true outcome is the tickets or bugs that we find with our difficult experiences. We then log all the amazing issues and cross compaire them against our customer findings so we can see the overlap. 
+![gameplay](overview.gif?raw=true)
 
-What is left over is some amazing content that we hope the community finds fun, entertaining, and reusable for their own products. I'm looking forward to what you guys use it for. Many thanks and Enjoy!
+These gnomes have come into our world and stolen all our gold. They thought they could hide it where no one would ever find it. But we've found their home. Will you help us sneak into their world and get our gold back? You have to be careful though, these gnomes are clever and left traps for you everywhere. They also don't appear to be gone for long, so be back before the time runs out because at this point, Gnome-bodys home.
 
-#### Game Premise
+*The does not have interaction besides camera movements for now*
 
-These gnomes have come into our world and stolen all our gold. They thought they could hide it where no one would ever find it. But we've found their home. Will you help us sneak into their world and get our gold back? You have to be careful though, these gnomes are clevar and left traps for you everywhere. They also don't appear to be gone for long, so be back before the time runs out because at this point, Gnome-bodys home.
+## Prerequisites
 
+You need to build or [install O3DE engine](https://o3de.org/download/).
 
-#### Whats included in the Project.
-The UX workflow I was focusing on was around asset importing and assets manipulation Pipeline. With the new addition of Atom render we wanted to test out how these new workflow would effect our users. What the O3DE UX group would call the week one experience.  I focused on the level designer and asset creation workflow. So this project has 40+ assets I created in Maya, Photoshop, Illustrator. This world doesn't include any game logic or ScriptCanvas. I've removed all the prefab containers I was testing with to keep it simple.
+## How to run
+
+1. Download (green "Code" button, then "Download ZIP") or clone the github repository (`git clone https://github.com/o3de/GnomebodysHome.git`)
+2. Launch O3DE. It will open the Project manager. Click on the **New Project** button then **Open Existing Project** option.
+3. Navigate to your download (and make sure it is unzipped). Open the folder. The project should now be registered.
 
 ![GnomeLogo](https://user-images.githubusercontent.com/82551958/138384854-6098fb16-53bb-4b14-b880-0a2ce610e8e3.png)
+
+4. Click on the **Build Project** button, located on the **GameJam2021** image.
+5. Once the project has been built sucessfully, use the **Open Editor** button.
+6. The asset pre-processor will run for a bit. Once it is over you will be welcomed with the **Open a Level** window. Pick the first one.
+
+## Project Highlights
+
+https://user-images.githubusercontent.com/62353586/139504735-660aff2c-ae77-4c72-a996-38f4043fba5a.mp4
+
+- **40+ custom assets**, containing terrains, vegetation, materials and gnomes
+- **Script playground**, the game idea is there but scripting needs to be added, maybe you can be up to it ?
+
+### Screenshots
 
 ![ResourceIMG0148](https://user-images.githubusercontent.com/82551958/138385024-e87c972c-9799-4f8d-96cf-8d3bc16a3154.jpg)
 
@@ -29,8 +44,6 @@ The UX workflow I was focusing on was around asset importing and assets manipula
 ![ResourceIMG0145](https://user-images.githubusercontent.com/82551958/138385614-0feff6dc-f2ca-4014-bbda-f0fb17497d62.jpg)
 
 ![ResourceIMG0134](https://user-images.githubusercontent.com/82551958/138385250-18c199d3-660d-4bd2-b7f9-43095e58ea38.jpg)
-
-https://user-images.githubusercontent.com/62353586/139504735-660aff2c-ae77-4c72-a996-38f4043fba5a.mp4
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <u>Supported o3de versions</u> : **23.10**
 
-## Gnomebody's Home (By Joshua Rainbolt)
+# Gnomebody's Home (By Joshua Rainbolt)
 
 ![gameplay](overview.gif?raw=true)
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,18 @@ These gnomes have come into our world and stolen all our gold. They thought they
 
 You need to build or [install O3DE engine](https://o3de.org/download/).
 
+You need to [install git with lfs support](https://git-scm.com/downloads), and [setup a token on your github account](https://www.docs.o3de.org/docs/welcome-guide/setup/setup-from-github/#configure-credentials-for-git-lfs). Needed as the repository uses Git LFS, the "Download ZIP" button will not download assets.
+
 ## How to run
 
-1. Download (green "Code" button, then "Download ZIP") or clone the github repository (`git clone https://github.com/o3de/GnomebodysHome.git`)
+1. Clone the github repository (`git clone https://github.com/o3de/GnomebodysHome.git`). When prompted to authenticate, use your github username and the token as password.
 2. Launch O3DE. It will open the Project manager. Click on the **New Project** button then **Open Existing Project** option.
-3. Navigate to your download (and make sure it is unzipped). Open the folder. The project should now be registered.
+3. Navigate to the cloned repository. Open the folder. The project should now be registered.
 
 ![GnomeLogo](https://user-images.githubusercontent.com/82551958/138384854-6098fb16-53bb-4b14-b880-0a2ce610e8e3.png)
 
 4. Click on the **Build Project** button, located on the **GameJam2021** image.
-5. Once the project has been built sucessfully, use the **Open Editor** button.
+5. Once the project has been built successfully, use the **Open Editor** button.
 6. The asset pre-processor will run for a bit. Once it is over you will be welcomed with the **Open a Level** window. Pick the first one.
 
 ## Project Highlights

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<u>Supported o3de versions</u> : **23.10**
+
 ## Gnomebody's Home (By Joshua Rainbolt)
 
 ![gameplay](overview.gif?raw=true)

--- a/project.json
+++ b/project.json
@@ -13,5 +13,7 @@
     "icon_path": "preview.png",
     "engine": "o3de",
     "external_subdirectories": [],
-    "restricted_name": "projects"
+    "restricted_name": "projects",
+    "project_id": "{873840b2-e16d-4e10-9ca8-7382b1ac1a77}",
+    "engine_version": "2.2.2"
 }

--- a/project.json.bak0
+++ b/project.json.bak0
@@ -1,0 +1,20 @@
+{
+    "project_name": "GameJam2021",
+    "origin": "The primary repo for GameJam2021 goes here: i.e. http://www.mydomain.com",
+    "license": "What license GameJam2021 uses goes here: i.e. https://opensource.org/licenses/MIT",
+    "display_name": "GameJam2021",
+    "summary": "A short description of GameJam2021.",
+    "canonical_tags": [
+        "Project"
+    ],
+    "user_tags": [
+        "GameJam2021"
+    ],
+    "icon_path": "preview.png",
+    "engine": "o3de",
+    "external_subdirectories": [
+        "Gem"
+    ],
+    "restricted_name": "projects",
+    "project_id": "{873840b2-e16d-4e10-9ca8-7382b1ac1a77}"
+}


### PR DESCRIPTION
First take on an unified readme format used accross every O3DE samples (and checked that the project still runs correctly on the release of 23.10.3)

The goal being to make the samples more accessible to the users. Both by updating the project's readme, adding a version check and linking them in O3DE showcase and doc pages. Task tracked via this issue : https://github.com/o3de/o3de.org/issues/2549